### PR TITLE
docs: Make sure the correct package name is being used in the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started with the `esbuild-css-as-string` plugin, first ensure you have es
 
 ```sh
 npm install esbuild --save-dev
-npm install esbuild-css-as-string-plugin --save-dev
+npm install esbuild-css-as-string --save-dev
 ```
 
 ## Setup


### PR DESCRIPTION
Thanks for the plugin! 🙌
I just noticed a small error in the `README` when I was trying out the plugin.